### PR TITLE
ci: cache apt packages and Wails CLI binary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,12 +62,19 @@ jobs:
           node-version: "20"
           cache: npm
           cache-dependency-path: frontend/package-lock.json
-      - name: Install Linux deps
+      - name: Cache & install Linux deps
         if: runner.os == 'Linux'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev build-essential pkg-config
+        uses: awalsh128/cache-apt-pkgs-action@v1
+        with:
+          packages: libgtk-3-dev libwebkit2gtk-4.1-dev build-essential pkg-config
+      - name: Cache Wails CLI
+        id: cache-wails
+        uses: actions/cache@v4
+        with:
+          path: ~/go/bin/wails
+          key: wails-${{ runner.os }}-v2.11.0
       - name: Install Wails CLI
-        run: go install github.com/wailsapp/wails/v2/cmd/wails@latest
+        if: steps.cache-wails.outputs.cache-hit != 'true'
+        run: go install github.com/wailsapp/wails/v2/cmd/wails@v2.11.0
       - name: Build
         run: wails build ${{ runner.os == 'Linux' && '-tags webkit2_41' || '' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,13 +40,20 @@ jobs:
           node-version: "20"
           cache: npm
           cache-dependency-path: frontend/package-lock.json
-      - name: Install Linux deps
+      - name: Cache & install Linux deps
         if: runner.os == 'Linux'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev build-essential pkg-config
+        uses: awalsh128/cache-apt-pkgs-action@v1
+        with:
+          packages: libgtk-3-dev libwebkit2gtk-4.1-dev build-essential pkg-config
+      - name: Cache Wails CLI
+        id: cache-wails
+        uses: actions/cache@v4
+        with:
+          path: ~/go/bin/wails
+          key: wails-${{ runner.os }}-v2.11.0
       - name: Install Wails CLI
-        run: go install github.com/wailsapp/wails/v2/cmd/wails@latest
+        if: steps.cache-wails.outputs.cache-hit != 'true'
+        run: go install github.com/wailsapp/wails/v2/cmd/wails@v2.11.0
       - name: Build
         run: wails build ${{ runner.os == 'Linux' && '-tags webkit2_41' || '' }} -ldflags "-X main.versionSuffix="
 


### PR DESCRIPTION
## Summary

- Replace manual `apt-get install` with `awalsh128/cache-apt-pkgs-action@v1` to cache Linux deps between runs
- Cache `~/go/bin/wails` with `actions/cache@v4`, only running `go install` on cache miss
- Pin Wails CLI to `v2.11.0` (matches `go.mod`) instead of `@latest` for reproducibility

Closes #15

## Test plan

- [ ] Verify all CI jobs pass on this PR (first run populates caches)
- [ ] On a re-run or subsequent push, confirm cache hits in logs for apt packages and Wails CLI