### PR TITLE
ci: cache ~/go/bin directory instead of specific binary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
         id: cache-wails
         uses: actions/cache@v4
         with:
-          path: ~/go/bin/wails
+          path: ~/go/bin
           key: wails-${{ runner.os }}-v2.11.0
       - name: Install Wails CLI
         if: steps.cache-wails.outputs.cache-hit != 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
         id: cache-wails
         uses: actions/cache@v4
         with:
-          path: ~/go/bin/wails
+          path: ~/go/bin
           key: wails-${{ runner.os }}-v2.11.0
       - name: Install Wails CLI
         if: steps.cache-wails.outputs.cache-hit != 'true'


### PR DESCRIPTION
## Summary

- Cache `~/go/bin` directory instead of `~/go/bin/wails` to fix cache save warning on Windows (where the binary is `wails.exe`)

Follow-up to #16.

## Test plan

- [ ] Verify no "Path Validation Error" warning on Windows runner
- [ ] Confirm cache hit on subsequent runs across all platforms