### PR TITLE
fix: correct UI labels and improve build setup

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,4 +1,5 @@
 [tools]
 go = "1.25"
+node = "23.2"
 golangci-lint = "latest"
 lefthook = "latest"

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,7 @@
-.PHONY: lint frontend-check test dev build ci
+.PHONY: setup lint frontend-check test dev build ci
+
+setup:
+	go install github.com/wailsapp/wails/v2/cmd/wails@latest
 
 lint: frontend-build
 	golangci-lint run

--- a/README.md
+++ b/README.md
@@ -52,13 +52,26 @@ Download the latest release for your platform from the [Releases](https://github
 | Windows  | `Goldsplit-windows-amd64.exe` |
 | Linux    | `goldsplit-linux-amd64` |
 
+> **macOS note:** The binary is not signed. On first launch, macOS Gatekeeper will block it. To allow it, run:
+> ```sh
+> xattr -cr /Applications/Goldsplit.app
+> ```
+> Alternatively, you can [build from source](#building-from-source).
+
 ## Building from Source
 
 ### Prerequisites
 
 - [Go](https://go.dev/) 1.25+
-- [Node.js](https://nodejs.org/) (for the frontend)
-- [Wails CLI](https://wails.io/docs/gettingstarted/installation) v2
+- [Node.js](https://nodejs.org/) 23+
+
+> **Tip:** If you use [mise](https://mise.jdx.dev/), run `mise install` to set up Go, Node.js, and dev tools automatically.
+
+Then install the Wails CLI:
+
+```sh
+make setup
+```
 
 **Linux only:** GTK and WebKit development libraries are required. See [Wails Linux prerequisites](https://wails.io/docs/gettingstarted/installation#platform-specific-dependencies).
 
@@ -84,6 +97,7 @@ make dev
 
 | Target | Description |
 |--------|-------------|
+| `make setup` | Install Wails CLI and other Go tools |
 | `make dev` | Start Wails dev server with hot reload |
 | `make build` | Production build |
 | `make lint` | Run golangci-lint (builds frontend first) |


### PR DESCRIPTION
## Summary
- Fix UI text using correct Game → Category → Attempt hierarchy
- Fix "Best Times" → "Best Segments" in comparison dropdown
- Rename `AttemptsSetup.svelte` → `CategorySetup.svelte`
- Add macOS Gatekeeper note to README
- Add Node.js 23.2 to `.mise.toml`
- Add `make setup` target to install Wails CLI
- Update README prerequisites with mise tip

## Test plan
- [ ] "New Category" screen title displays correctly
- [ ] Empty state says "No categories yet"
- [ ] Delete game dialog says "all its categories"
- [ ] Comparison dropdown says "Best Segments"
- [ ] `make setup` installs Wails CLI
- [ ] `mise install` sets up Go, Node.js, and dev tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)